### PR TITLE
Improve code style

### DIFF
--- a/RTNetworking.xcodeproj/project.pbxproj
+++ b/RTNetworking.xcodeproj/project.pbxproj
@@ -8,17 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		4042907D7B104E208300D61A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F75ADC2FB88145EC90EC652D /* libPods.a */; };
-		4A00B5AF192EF1F2004C25C0 /* AIFApiProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A00B5AE192EF1F2004C25C0 /* AIFApiProxy.m */; };
+		4A00B5AF192EF1F2004C25C0 /* AIFAPIProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A00B5AE192EF1F2004C25C0 /* AIFAPIProxy.m */; };
 		4A05167D1928FAF20025C4E1 /* AIFCityListManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A0516771928FAF10025C4E1 /* AIFCityListManager.m */; };
 		4A05167E1928FAF20025C4E1 /* AIFLocationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A0516791928FAF10025C4E1 /* AIFLocationManager.m */; };
-		4A05167F1928FAF20025C4E1 /* AIFPListManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A05167C1928FAF20025C4E1 /* AIFPListManager.m */; };
+		4A05167F1928FAF20025C4E1 /* AIFPlistManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A05167C1928FAF20025C4E1 /* AIFPlistManager.m */; };
 		4A0516821928FB5C0025C4E1 /* RTAPIBaseManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A0516811928FB5C0025C4E1 /* RTAPIBaseManager.m */; };
 		4A165E00192A045D00CCC80F /* AIFLoggerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A165DFD192A045D00CCC80F /* AIFLoggerConfiguration.m */; };
 		4A165E01192A045D00CCC80F /* AIFLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A165DFF192A045D00CCC80F /* AIFLogger.m */; };
 		4A54102C1918D7D90070C64C /* AIFCommonParamsGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A54102B1918D7D90070C64C /* AIFCommonParamsGenerator.m */; };
 		4A54102F1918D94C0070C64C /* NSDictionary+AXNetworkingMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A54102E1918D94C0070C64C /* NSDictionary+AXNetworkingMethods.m */; };
 		4A5410321918E02E0070C64C /* NSObject+AXNetworkingMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5410311918E02E0070C64C /* NSObject+AXNetworkingMethods.m */; };
-		4A5410391918E38E0070C64C /* AIFAppContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5410381918E38E0070C64C /* AIFAppContext.m */; };
+		4A5410391918E38E0070C64C /* AIFAPPContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5410381918E38E0070C64C /* AIFAPPContext.m */; };
 		4A5AE55E1921AFF700E5DDAC /* AIFSignatureGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AE55D1921AFF700E5DDAC /* AIFSignatureGenerator.m */; };
 		4A5AE5631923075300E5DDAC /* AIFRequestGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AE5621923075300E5DDAC /* AIFRequestGenerator.m */; };
 		4A5AE56619244C1500E5DDAC /* AIFService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AE56519244C1500E5DDAC /* AIFService.m */; };
@@ -62,14 +62,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4A00B5AD192EF1F2004C25C0 /* AIFApiProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFApiProxy.h; sourceTree = "<group>"; };
-		4A00B5AE192EF1F2004C25C0 /* AIFApiProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFApiProxy.m; sourceTree = "<group>"; };
+		4A00B5AD192EF1F2004C25C0 /* AIFAPIProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFAPIProxy.h; sourceTree = "<group>"; };
+		4A00B5AE192EF1F2004C25C0 /* AIFAPIProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFAPIProxy.m; sourceTree = "<group>"; };
 		4A0516761928FAF10025C4E1 /* AIFCityListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFCityListManager.h; sourceTree = "<group>"; };
 		4A0516771928FAF10025C4E1 /* AIFCityListManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFCityListManager.m; sourceTree = "<group>"; };
 		4A0516781928FAF10025C4E1 /* AIFLocationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFLocationManager.h; sourceTree = "<group>"; };
 		4A0516791928FAF10025C4E1 /* AIFLocationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFLocationManager.m; sourceTree = "<group>"; };
-		4A05167B1928FAF10025C4E1 /* AIFPListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFPListManager.h; sourceTree = "<group>"; };
-		4A05167C1928FAF20025C4E1 /* AIFPListManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFPListManager.m; sourceTree = "<group>"; };
+		4A05167B1928FAF10025C4E1 /* AIFPlistManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFPlistManager.h; sourceTree = "<group>"; };
+		4A05167C1928FAF20025C4E1 /* AIFPlistManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFPlistManager.m; sourceTree = "<group>"; };
 		4A0516801928FB5C0025C4E1 /* RTAPIBaseManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RTAPIBaseManager.h; sourceTree = "<group>"; };
 		4A0516811928FB5C0025C4E1 /* RTAPIBaseManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RTAPIBaseManager.m; sourceTree = "<group>"; };
 		4A165DFC192A045D00CCC80F /* AIFLoggerConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFLoggerConfiguration.h; sourceTree = "<group>"; };
@@ -83,8 +83,8 @@
 		4A54102E1918D94C0070C64C /* NSDictionary+AXNetworkingMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+AXNetworkingMethods.m"; sourceTree = "<group>"; };
 		4A5410301918E02E0070C64C /* NSObject+AXNetworkingMethods.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+AXNetworkingMethods.h"; sourceTree = "<group>"; };
 		4A5410311918E02E0070C64C /* NSObject+AXNetworkingMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+AXNetworkingMethods.m"; sourceTree = "<group>"; };
-		4A5410371918E38E0070C64C /* AIFAppContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFAppContext.h; sourceTree = "<group>"; };
-		4A5410381918E38E0070C64C /* AIFAppContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFAppContext.m; sourceTree = "<group>"; };
+		4A5410371918E38E0070C64C /* AIFAPPContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFAPPContext.h; sourceTree = "<group>"; };
+		4A5410381918E38E0070C64C /* AIFAPPContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFAPPContext.m; sourceTree = "<group>"; };
 		4A5AE55C1921AFF700E5DDAC /* AIFSignatureGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFSignatureGenerator.h; sourceTree = "<group>"; };
 		4A5AE55D1921AFF700E5DDAC /* AIFSignatureGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AIFSignatureGenerator.m; sourceTree = "<group>"; };
 		4A5AE5601921CDA000E5DDAC /* AIFNetworkingConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AIFNetworkingConfiguration.h; sourceTree = "<group>"; };
@@ -181,8 +181,8 @@
 		4A05167A1928FAF10025C4E1 /* PlistManager */ = {
 			isa = PBXGroup;
 			children = (
-				4A05167B1928FAF10025C4E1 /* AIFPListManager.h */,
-				4A05167C1928FAF20025C4E1 /* AIFPListManager.m */,
+				4A05167B1928FAF10025C4E1 /* AIFPlistManager.h */,
+				4A05167C1928FAF20025C4E1 /* AIFPlistManager.m */,
 			);
 			path = PlistManager;
 			sourceTree = "<group>";
@@ -230,8 +230,8 @@
 				4A54102E1918D94C0070C64C /* NSDictionary+AXNetworkingMethods.m */,
 				4A5410301918E02E0070C64C /* NSObject+AXNetworkingMethods.h */,
 				4A5410311918E02E0070C64C /* NSObject+AXNetworkingMethods.m */,
-				4A6904C5191903BE00BA4622 /* UIDevice+IdentifierAddition.m */,
 				4A6904C6191903BE00BA4622 /* UIDevice+IdentifierAddition.h */,
+				4A6904C5191903BE00BA4622 /* UIDevice+IdentifierAddition.m */,
 				4A6904C8191903DF00BA4622 /* NSString+AXNetworkingMethods.h */,
 				4A6904C9191903DF00BA4622 /* NSString+AXNetworkingMethods.m */,
 				4AF9117A19226AD300310140 /* NSArray+AXNetworkingMethods.h */,
@@ -265,14 +265,14 @@
 				4A165DFB192A045D00CCC80F /* LogComponents */,
 				4A0516751928FAF10025C4E1 /* LocationComponents */,
 				4ABAA3531932ED95007C99EC /* CacheComponents */,
-				4A5410371918E38E0070C64C /* AIFAppContext.h */,
-				4A5410381918E38E0070C64C /* AIFAppContext.m */,
+				4A5410371918E38E0070C64C /* AIFAPPContext.h */,
+				4A5410381918E38E0070C64C /* AIFAPPContext.m */,
 				4AA8397B1928D56F0085CB3F /* AIFURLResponse.h */,
 				4AA8397C1928D56F0085CB3F /* AIFURLResponse.m */,
 				4A0516801928FB5C0025C4E1 /* RTAPIBaseManager.h */,
 				4A0516811928FB5C0025C4E1 /* RTAPIBaseManager.m */,
-				4A00B5AD192EF1F2004C25C0 /* AIFApiProxy.h */,
-				4A00B5AE192EF1F2004C25C0 /* AIFApiProxy.m */,
+				4A00B5AD192EF1F2004C25C0 /* AIFAPIProxy.h */,
+				4A00B5AE192EF1F2004C25C0 /* AIFAPIProxy.m */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -523,7 +523,7 @@
 				4A95FC29193199BF0038C622 /* AIFServiceGoogleMapDirections.m in Sources */,
 				4AF9117C19226AD300310140 /* NSArray+AXNetworkingMethods.m in Sources */,
 				4A0516821928FB5C0025C4E1 /* RTAPIBaseManager.m in Sources */,
-				4A00B5AF192EF1F2004C25C0 /* AIFApiProxy.m in Sources */,
+				4A00B5AF192EF1F2004C25C0 /* AIFAPIProxy.m in Sources */,
 				4AB27CBD1927B11600C7ADFA /* NSMutableString+AXNetworkingMethods.m in Sources */,
 				4A05167D1928FAF20025C4E1 /* AIFCityListManager.m in Sources */,
 				4AD829ED1918B581001A90DF /* AppDelegate.m in Sources */,
@@ -531,10 +531,10 @@
 				4A6904C7191903BE00BA4622 /* UIDevice+IdentifierAddition.m in Sources */,
 				4ABAA3591932EDEA007C99EC /* AIFCache.m in Sources */,
 				4A165E01192A045D00CCC80F /* AIFLogger.m in Sources */,
-				4A05167F1928FAF20025C4E1 /* AIFPListManager.m in Sources */,
+				4A05167F1928FAF20025C4E1 /* AIFPlistManager.m in Sources */,
 				4AD829E91918B581001A90DF /* main.m in Sources */,
 				4A54102C1918D7D90070C64C /* AIFCommonParamsGenerator.m in Sources */,
-				4A5410391918E38E0070C64C /* AIFAppContext.m in Sources */,
+				4A5410391918E38E0070C64C /* AIFAPPContext.m in Sources */,
 				4A165E00192A045D00CCC80F /* AIFLoggerConfiguration.m in Sources */,
 				4ADC85AB192086AF00217C4B /* AIFServiceFactory.m in Sources */,
 			);

--- a/RTNetworking/Components/AIFNetworking.h
+++ b/RTNetworking/Components/AIFNetworking.h
@@ -9,9 +9,9 @@
 #ifndef RTNetworking_AXNetworking_h
 #define RTNetworking_AXNetworking_h
 
-#import "AIFApiProxy.h"
+#import "AIFAPIProxy.h"
 #import "AIFServiceFactory.h"
-#import "AIFAppContext.h"
+#import "AIFAPPContext.h"
 #import "RTAPIBaseManager.h"
 #import "AIFNetworkingConfiguration.h"
 

--- a/RTNetworking/Components/Assistants/AIFCommonParamsGenerator.m
+++ b/RTNetworking/Components/Assistants/AIFCommonParamsGenerator.m
@@ -7,14 +7,14 @@
 //
 
 #import "AIFCommonParamsGenerator.h"
-#import "AIFAppContext.h"
+#import "AIFAPPContext.h"
 #import "NSDictionary+AXNetworkingMethods.h"
 
 @implementation AIFCommonParamsGenerator
 
 + (NSDictionary *)commonParamsDictionary
 {
-    AIFAppContext *context = [AIFAppContext sharedInstance];
+    AIFAPPContext *context = [AIFAPPContext sharedInstance];
     return @{
              @"cid":context.cid,
              @"ostype2":context.ostype2,
@@ -36,7 +36,7 @@
 
 + (NSDictionary *)commonParamsDictionaryForLog
 {
-    AIFAppContext *context = [AIFAppContext sharedInstance];
+    AIFAPPContext *context = [AIFAPPContext sharedInstance];
     return @{
              @"guid":context.guid,
              @"dvid":context.dvid,

--- a/RTNetworking/Components/Assistants/AIFRequestGenerator.m
+++ b/RTNetworking/Components/Assistants/AIFRequestGenerator.m
@@ -72,7 +72,7 @@
 {
     AIFService *service = [[AIFServiceFactory sharedInstance] serviceWithIdentifier:serviceIdentifier];
     NSString *signature = [AIFSignatureGenerator signPostWithApiParams:requestParams privateKey:service.privateKey publicKey:service.publicKey];
-    NSString *urlString = [NSString stringWithFormat:@"%@%@/%@?api_key=%@&sig=%@&%@", service.apiBaseUrl, service.apiVersion, methodName, service.publicKey, signature, [[AIFCommonParamsGenerator commonParamsDictionary] AIF_urlParamsStringSignature:NO]];
+    NSString *urlString = [NSString stringWithFormat:@"%@%@/%@?api_key=%@&sig=%@&%@", service.apiBaseUrl, service.apiVersion, methodName, service.publicKey, signature, [[AIFCommonParamsGenerator commonParamsDictionary] aif_urlParamsStringSignature:NO]];
     
     NSURLRequest *request = [self.httpRequestSerializer requestWithMethod:@"POST" URLString:urlString parameters:requestParams error:NULL];
     request.requestParams = requestParams;
@@ -105,7 +105,7 @@
     AIFService *service = [[AIFServiceFactory sharedInstance] serviceWithIdentifier:serviceIdentifier];
     NSDictionary *commonParams = [AIFCommonParamsGenerator commonParamsDictionary];
     NSString *signature = [AIFSignatureGenerator signRestfulPOSTWithApiParams:requestParams commonParams:commonParams methodName:methodName apiVersion:service.apiVersion privateKey:service.privateKey];
-    NSString *urlString = [NSString stringWithFormat:@"%@%@/%@?&%@", service.apiBaseUrl, service.apiVersion, methodName, [commonParams AIF_urlParamsStringSignature:NO]];
+    NSString *urlString = [NSString stringWithFormat:@"%@%@/%@?&%@", service.apiBaseUrl, service.apiVersion, methodName, [commonParams aif_urlParamsStringSignature:NO]];
     
     NSDictionary *restfulHeader = [self commRESTHeadersWithService:service signature:signature];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:kAIFNetworkingTimeoutSeconds];
@@ -122,7 +122,7 @@
 - (NSURLRequest *)generateGoolgeMapAPIRequestWithParams:(NSDictionary *)requestParams serviceIdentifier:(NSString *)serviceIdentifier
 {
     AIFService *service = [[AIFServiceFactory sharedInstance] serviceWithIdentifier:serviceIdentifier];
-    NSString *paramsString = [requestParams AIF_urlParamsStringSignature:NO];
+    NSString *paramsString = [requestParams aif_urlParamsStringSignature:NO];
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@?%@", service.apiBaseUrl, service.apiVersion, paramsString]];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:kAIFNetworkingTimeoutSeconds];
     [request setValue:@"zh-CN,zh;q=0.8,en;q=0.6" forHTTPHeaderField:@"Accept-Language"];

--- a/RTNetworking/Components/Assistants/AIFUDIDGenerator.m
+++ b/RTNetworking/Components/Assistants/AIFUDIDGenerator.m
@@ -133,4 +133,5 @@
     NSDictionary *dict = [NSKeyedUnarchiver unarchiveObjectWithData:[pb dataForPasteboardType:AIFPasteboardType]];
     return [dict objectForKey:identifier];
 }
+
 @end

--- a/RTNetworking/Components/Categories/NSArray+AXNetworkingMethods.h
+++ b/RTNetworking/Components/Categories/NSArray+AXNetworkingMethods.h
@@ -10,7 +10,7 @@
 
 @interface NSArray (AXNetworkingMethods)
 
-- (NSString *)AX_paramsString;
-- (NSString *)AX_jsonString;
+- (NSString *)ax_paramsString;
+- (NSString *)ax_jsonString;
 
 @end

--- a/RTNetworking/Components/Categories/NSArray+AXNetworkingMethods.m
+++ b/RTNetworking/Components/Categories/NSArray+AXNetworkingMethods.m
@@ -11,7 +11,7 @@
 @implementation NSArray (AXNetworkingMethods)
 
 /** 字母排序之后形成的参数字符串 */
-- (NSString *)AX_paramsString
+- (NSString *)ax_paramsString
 {
     NSMutableString *paramString = [[NSMutableString alloc] init];
     
@@ -28,7 +28,7 @@
 }
 
 /** 数组变json */
-- (NSString *)AX_jsonString
+- (NSString *)ax_jsonString
 {
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self options:NSJSONWritingPrettyPrinted error:NULL];
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];

--- a/RTNetworking/Components/Categories/NSDictionary+AXNetworkingMethods.h
+++ b/RTNetworking/Components/Categories/NSDictionary+AXNetworkingMethods.h
@@ -10,8 +10,8 @@
 
 @interface NSDictionary (AXNetworkingMethods)
 
-- (NSString *)AIF_urlParamsStringSignature:(BOOL)isForSignature;
-- (NSString *)AIF_jsonString;
-- (NSArray *)AIF_transformedUrlParamsArraySignature:(BOOL)isForSignature;
+- (NSString *)aif_urlParamsStringSignature:(BOOL)isForSignature;
+- (NSString *)aif_jsonString;
+- (NSArray *)aif_transformedUrlParamsArraySignature:(BOOL)isForSignature;
 
 @end

--- a/RTNetworking/Components/Categories/NSDictionary+AXNetworkingMethods.m
+++ b/RTNetworking/Components/Categories/NSDictionary+AXNetworkingMethods.m
@@ -12,21 +12,21 @@
 @implementation NSDictionary (AXNetworkingMethods)
 
 /** 字符串前面是没有问号的，如果用于POST，那就不用加问号，如果用于GET，就要加个问号 */
-- (NSString *)AIF_urlParamsStringSignature:(BOOL)isForSignature
+- (NSString *)aif_urlParamsStringSignature:(BOOL)isForSignature
 {
-    NSArray *sortedArray = [self AIF_transformedUrlParamsArraySignature:isForSignature];
-    return [sortedArray AX_paramsString];
+    NSArray *sortedArray = [self aif_transformedUrlParamsArraySignature:isForSignature];
+    return [sortedArray ax_paramsString];
 }
 
 /** 字典变json */
-- (NSString *)AIF_jsonString
+- (NSString *)aif_jsonString
 {
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self options:NSJSONWritingPrettyPrinted error:NULL];
     return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
 }
 
 /** 转义参数 */
-- (NSArray *)AIF_transformedUrlParamsArraySignature:(BOOL)isForSignature
+- (NSArray *)aif_transformedUrlParamsArraySignature:(BOOL)isForSignature
 {
     NSMutableArray *result = [[NSMutableArray alloc] init];
     [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {

--- a/RTNetworking/Components/Categories/NSMutableString+AXNetworkingMethods.m
+++ b/RTNetworking/Components/Categories/NSMutableString+AXNetworkingMethods.m
@@ -15,7 +15,7 @@
 {
     [self appendFormat:@"\n\nHTTP URL:\n\t%@", request.URL];
     [self appendFormat:@"\n\nHTTP Header:\n%@", request.allHTTPHeaderFields ? request.allHTTPHeaderFields : @"\t\t\t\t\tN/A"];
-    [self appendFormat:@"\n\nHTTP Body:\n\t%@", [[[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding] AIF_defaultValue:@"\t\t\t\tN/A"]];
+    [self appendFormat:@"\n\nHTTP Body:\n\t%@", [[[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding] aif_defaultValue:@"\t\t\t\tN/A"]];
 }
 
 @end

--- a/RTNetworking/Components/Categories/NSObject+AXNetworkingMethods.h
+++ b/RTNetworking/Components/Categories/NSObject+AXNetworkingMethods.h
@@ -10,7 +10,7 @@
 
 @interface NSObject (AXNetworkingMethods)
 
-- (id)AIF_defaultValue:(id)defaultData;
-- (BOOL)AIF_isEmptyObject;
+- (id)aif_defaultValue:(id)defaultData;
+- (BOOL)aif_isEmptyObject;
 
 @end

--- a/RTNetworking/Components/Categories/NSObject+AXNetworkingMethods.m
+++ b/RTNetworking/Components/Categories/NSObject+AXNetworkingMethods.m
@@ -10,20 +10,20 @@
 
 @implementation NSObject (AXNetworkingMethods)
 
-- (id)AIF_defaultValue:(id)defaultData
+- (id)aif_defaultValue:(id)defaultData
 {
     if (![defaultData isKindOfClass:[self class]]) {
         return defaultData;
     }
     
-    if ([self AIF_isEmptyObject]) {
+    if ([self aif_isEmptyObject]) {
         return defaultData;
     }
     
     return self;
 }
 
-- (BOOL)AIF_isEmptyObject
+- (BOOL)aif_isEmptyObject
 {
     if ([self isEqual:[NSNull null]]) {
         return YES;

--- a/RTNetworking/Components/Categories/NSString+AXNetworkingMethods.h
+++ b/RTNetworking/Components/Categories/NSString+AXNetworkingMethods.h
@@ -10,7 +10,7 @@
 
 @interface NSString (AXNetworkingMethods)
 
-- (NSString *)AX_md5;
+- (NSString *)ax_md5;
 
 
 @end

--- a/RTNetworking/Components/Categories/NSString+AXNetworkingMethods.m
+++ b/RTNetworking/Components/Categories/NSString+AXNetworkingMethods.m
@@ -12,7 +12,7 @@
 
 @implementation NSString (AXNetworkingMethods)
 
-- (NSString *)AX_md5
+- (NSString *)ax_md5
 {
 	NSData* inputData = [self dataUsingEncoding:NSUTF8StringEncoding];
 	unsigned char outputData[CC_MD5_DIGEST_LENGTH];

--- a/RTNetworking/Components/Categories/UIDevice+IdentifierAddition.h
+++ b/RTNetworking/Components/Categories/UIDevice+IdentifierAddition.h
@@ -16,20 +16,21 @@
  * @description apple identifier support iOS6 and iOS5 below
  */
 
-- (NSString *) AIF_uuid;
-- (NSString *) AIF_udid;
-- (NSString *) AIF_macaddress;
-- (NSString *) AIF_macaddressMD5;
-- (NSString *) AIF_machineType;
-- (NSString *) AIF_ostype;//显示“ios6，ios5”，只显示大版本号
-- (NSString *) AIF_createUUID;
+- (NSString *)aif_uuid;
+- (NSString *)aif_udid;
+- (NSString *)aif_macaddress;
+- (NSString *)aif_macaddressMD5;
+- (NSString *)aif_machineType;
+- (NSString *)aif_ostype; //显示“ios6，ios5”，只显示大版本号
+- (NSString *)aif_createUUID;
 
 //兼容旧版本
-- (NSString *) uuid;
-- (NSString *) udid;
-- (NSString *) macaddress;
-- (NSString *) macaddressMD5;
-- (NSString *) machineType;
-- (NSString *) ostype;//显示“ios6，ios5”，只显示大版本号
-- (NSString *) createUUID;
+- (NSString *)uuid;
+- (NSString *)udid;
+- (NSString *)macaddress;
+- (NSString *)macaddressMD5;
+- (NSString *)machineType;
+- (NSString *)ostype;//显示“ios6，ios5”，只显示大版本号
+- (NSString *)createUUID;
+
 @end

--- a/RTNetworking/Components/Categories/UIDevice+IdentifierAddition.m
+++ b/RTNetworking/Components/Categories/UIDevice+IdentifierAddition.m
@@ -81,7 +81,7 @@
 #pragma mark -
 #pragma mark Public Methods
 
-- (NSString *)AIF_createUUID
+- (NSString *)aif_createUUID
 {
     CFUUIDRef uuid = CFUUIDCreate(NULL);
     CFStringRef string = CFUUIDCreateString(NULL, uuid);
@@ -89,29 +89,29 @@
     return (__bridge NSString *)string;
 }
 
-- (NSString *)AIF_uuid
+- (NSString *)aif_uuid
 {
     NSString *key = @"RTUUID";
     NSString *uuid = [[NSUserDefaults standardUserDefaults] objectForKey:key];
     if (uuid.length == 0) {
-        [[NSUserDefaults standardUserDefaults] setObject:[self AIF_createUUID] forKey:key];
+        [[NSUserDefaults standardUserDefaults] setObject:[self aif_createUUID] forKey:key];
         return [[NSUserDefaults standardUserDefaults] objectForKey:key];
     } else {
         return uuid;
     }
 }
 
-- (NSString *) AIF_udid
+- (NSString *)aif_udid
 {
     NSString *udid = [[AIFUDIDGenerator sharedInstance] UDID];
     if (udid.length==0) {
-        udid = [self AIF_uuid];
+        udid = [self aif_uuid];
         [[AIFUDIDGenerator sharedInstance] saveUDID:udid];
     }
     return udid;
 }
 
-- (NSString *)AIF_macaddress
+- (NSString *)aif_macaddress
 {
     NSString *key = @"macAddress";
     NSString *macAddress = [[NSUserDefaults standardUserDefaults] objectForKey:key];
@@ -126,12 +126,13 @@
     return macAddress;       
 }
 
-- (NSString *) AIF_macaddressMD5{
+- (NSString *)aif_macaddressMD5
+{
     NSString *key = @"MACAddressMD5";
     NSString *macid = [[NSUserDefaults standardUserDefaults] objectForKey:key];
     if (macid.length == 0) {
-        NSString *macaddress = [[UIDevice currentDevice] AIF_macaddress];
-        macid = [macaddress AX_md5];
+        NSString *macaddress = [[UIDevice currentDevice] aif_macaddress];
+        macid = [macaddress ax_md5];
         if (!macid){
             macid = @"macaddress_empty";
         }else{
@@ -142,7 +143,7 @@
     return macid;
 }
 
-- (NSString *)AIF_machineType
+- (NSString *)aif_machineType
 {
     struct utsname systemInfo;
     uname(&systemInfo);
@@ -184,7 +185,8 @@
     return machineType;
 }
 
-- (NSString *) AIF_ostype{
+- (NSString *)aif_ostype
+{
     UIDevice *device = [UIDevice currentDevice];
     NSString *os = [device systemVersion];
     NSArray *array = [os componentsSeparatedByString:@"."];
@@ -196,33 +198,39 @@
 }
 
 #pragma mark - 兼容旧版本
-- (NSString *) uuid
+- (NSString *)uuid
 {
-    return self.AIF_uuid;
+    return self.aif_uuid;
 }
-- (NSString *) udid
+
+- (NSString *)udid
 {
-    return self.AIF_udid;
+    return self.aif_udid;
 }
-- (NSString *) macaddress
+
+- (NSString *)macaddress
 {
-    return self.AIF_macaddress;
+    return self.aif_macaddress;
 }
-- (NSString *) macaddressMD5
+
+- (NSString *)macaddressMD5
 {
-    return self.AIF_macaddressMD5;
+    return self.aif_macaddressMD5;
 }
-- (NSString *) machineType
+
+- (NSString *)machineType
 {
-    return self.AIF_machineType;
+    return self.aif_machineType;
 }
-- (NSString *) ostype//显示“ios6，ios5”，只显示大版本号
+
+- (NSString *)ostype //显示“ios6，ios5”，只显示大版本号
 {
-    return self.AIF_ostype;
+    return self.aif_ostype;
 }
-- (NSString *) createUUID
+
+- (NSString *)createUUID
 {
-    return self.AIF_createUUID;
+    return self.aif_createUUID;
 }
 
 @end

--- a/RTNetworking/Components/Components/AIFAPIProxy.h
+++ b/RTNetworking/Components/Components/AIFAPIProxy.h
@@ -11,7 +11,7 @@
 
 typedef void(^AXCallback)(AIFURLResponse *response);
 
-@interface AIFApiProxy : NSObject
+@interface AIFAPIProxy : NSObject
 
 + (instancetype)sharedInstance;
 

--- a/RTNetworking/Components/Components/AIFAPIProxy.m
+++ b/RTNetworking/Components/Components/AIFAPIProxy.m
@@ -7,7 +7,7 @@
 //
 
 #import <AFNetworking/AFNetworking.h>
-#import "AIFApiProxy.h"
+#import "AIFAPIProxy.h"
 #import "AIFServiceFactory.h"
 #import "AIFRequestGenerator.h"
 #import "AIFLogger.h"
@@ -17,7 +17,7 @@
 static NSString * const kAXApiProxyDispatchItemKeyCallbackSuccess = @"kAXApiProxyDispatchItemCallbackSuccess";
 static NSString * const kAXApiProxyDispatchItemKeyCallbackFail = @"kAXApiProxyDispatchItemCallbackFail";
 
-@interface AIFApiProxy ()
+@interface AIFAPIProxy ()
 
 @property (nonatomic, strong) NSMutableDictionary *dispatchTable;
 @property (nonatomic, strong) NSNumber *recordedRequestId;
@@ -27,7 +27,7 @@ static NSString * const kAXApiProxyDispatchItemKeyCallbackFail = @"kAXApiProxyDi
 
 @end
 
-@implementation AIFApiProxy
+@implementation AIFAPIProxy
 #pragma mark - getters and setters
 - (NSMutableDictionary *)dispatchTable
 {
@@ -50,9 +50,9 @@ static NSString * const kAXApiProxyDispatchItemKeyCallbackFail = @"kAXApiProxyDi
 + (instancetype)sharedInstance
 {
     static dispatch_once_t onceToken;
-    static AIFApiProxy *sharedInstance = nil;
+    static AIFAPIProxy *sharedInstance = nil;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[AIFApiProxy alloc] init];
+        sharedInstance = [[AIFAPIProxy alloc] init];
     });
     return sharedInstance;
 }

--- a/RTNetworking/Components/Components/AIFAPPContext.h
+++ b/RTNetworking/Components/Components/AIFAPPContext.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "AIFNetworkingConfiguration.h"
 
-@interface AIFAppContext : NSObject
+@interface AIFAPPContext : NSObject
 
 //凡是未声明成readonly的都是需要在初始化的时候由外面给的
 

--- a/RTNetworking/Components/Components/AIFAPPContext.m
+++ b/RTNetworking/Components/Components/AIFAPPContext.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014年 anjuke. All rights reserved.
 //
 
-#import "AIFAppContext.h"
+#import "AIFAPPContext.h"
 #import "NSObject+AXNetworkingMethods.h"
 #import "UIDevice+IdentifierAddition.h"
 #import "AFNetworkReachabilityManager.h"
@@ -15,7 +15,7 @@
 #import <ifaddrs.h>
 #import <arpa/inet.h>
 
-@interface AIFAppContext ()
+@interface AIFAPPContext ()
 
 @property (nonatomic, strong) UIDevice *device;
 @property (nonatomic, copy, readwrite) NSString *m;
@@ -38,7 +38,7 @@
 
 @end
 
-@implementation AIFAppContext
+@implementation AIFAPPContext
 
 #pragma mark - getters and setters
 - (UIDevice *)device
@@ -52,7 +52,7 @@
 - (NSString *)m
 {
     if (_m == nil) {
-        _m = [[self.device.model stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] AIF_defaultValue:@""];
+        _m = [[self.device.model stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] aif_defaultValue:@""];
     }
     return _m;
 }
@@ -60,7 +60,7 @@
 - (NSString *)o
 {
     if (_o == nil) {
-        _o = [[self.device.systemName stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] AIF_defaultValue:@""];
+        _o = [[self.device.systemName stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] aif_defaultValue:@""];
     }
     return _o;
 }
@@ -80,7 +80,7 @@
 - (NSString *)cv
 {
     if (_cv == nil) {
-        _cv = [[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] AIF_defaultValue:@""];
+        _cv = [[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"] aif_defaultValue:@""];
     }
     return _cv;
 }
@@ -93,7 +93,7 @@
 - (NSString *)macid
 {
     if (_macid == nil) {
-        _macid = [[self.device AIF_macaddressMD5] AIF_defaultValue:@""];
+        _macid = [[self.device aif_macaddressMD5] aif_defaultValue:@""];
     }
     return _macid;
 }
@@ -101,7 +101,7 @@
 - (NSString *)uuid
 {
     if (_uuid == nil) {
-        _uuid = [[self.device AIF_uuid] AIF_defaultValue:@""];
+        _uuid = [[self.device aif_uuid] aif_defaultValue:@""];
     }
     return _uuid;
 }
@@ -117,7 +117,7 @@
 - (NSString *)ostype2
 {
     if (_ostype2 == nil) {
-        _ostype2 = [self.device.AIF_ostype AIF_defaultValue:@""];
+        _ostype2 = [self.device.aif_ostype aif_defaultValue:@""];
     }
     return _ostype2;
 }
@@ -125,7 +125,7 @@
 - (NSString *)uuid2
 {
     if (_uuid2 == nil) {
-        _uuid2 = [self.device.AIF_uuid AIF_defaultValue:@""];
+        _uuid2 = [self.device.aif_uuid aif_defaultValue:@""];
     }
     return _uuid2;
 }
@@ -133,7 +133,7 @@
 - (NSString *)udid2
 {
     if (_udid2 == nil) {
-        _udid2 = [self.device.AIF_uuid AIF_defaultValue:@""];
+        _udid2 = [self.device.aif_uuid aif_defaultValue:@""];
     }
     return _udid2;
 }
@@ -304,7 +304,7 @@
 - (NSString *)pmodel
 {
     if (_pmodel == nil) {
-        _pmodel = [[UIDevice currentDevice] AIF_machineType];
+        _pmodel = [[UIDevice currentDevice] aif_machineType];
     }
     return _pmodel;
 }
@@ -321,10 +321,10 @@
 #pragma mark - public methods
 + (instancetype)sharedInstance
 {
-    static AIFAppContext *sharedInstance;
+    static AIFAPPContext *sharedInstance;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[AIFAppContext alloc] init];
+        sharedInstance = [[AIFAPPContext alloc] init];
         [[AFNetworkReachabilityManager sharedManager] startMonitoring];
         [AIFLocationManager sharedInstance];
     });

--- a/RTNetworking/Components/Components/AIFURLResponse.m
+++ b/RTNetworking/Components/Components/AIFURLResponse.m
@@ -45,7 +45,7 @@
 {
     self = [super init];
     if (self) {
-        self.contentString = [responseString AIF_defaultValue:@""];
+        self.contentString = [responseString aif_defaultValue:@""];
         self.status = [self responseStatusWithError:error];
         self.requestId = [requestId integerValue];
         self.request = request;

--- a/RTNetworking/Components/Components/CacheComponents/AIFCache.m
+++ b/RTNetworking/Components/Components/CacheComponents/AIFCache.m
@@ -93,7 +93,7 @@
 
 - (NSString *)keyWithServiceIdentifier:(NSString *)serviceIdentifier methodName:(NSString *)methodName requestParams:(NSDictionary *)requestParams
 {
-    return [NSString stringWithFormat:@"%@%@%@", serviceIdentifier, methodName, [requestParams AIF_urlParamsStringSignature:NO]];
+    return [NSString stringWithFormat:@"%@%@%@", serviceIdentifier, methodName, [requestParams aif_urlParamsStringSignature:NO]];
 }
 
 @end

--- a/RTNetworking/Components/Components/LocationComponents/AIFCityListManager.m
+++ b/RTNetworking/Components/Components/LocationComponents/AIFCityListManager.m
@@ -7,7 +7,7 @@
 //
 
 #import "AIFCityListManager.h"
-#import "AIFPListManager.h"
+#import "AIFPlistManager.h"
 #import "AIFNetworking.h"
 
 @interface AIFCityListManager ()
@@ -15,7 +15,7 @@
 @property (nonatomic, copy, readwrite) NSString *methodName;
 
 @property (nonatomic, copy) id cityData;
-@property (nonatomic, strong) AIFPListManager *plistManager;
+@property (nonatomic, strong) AIFPlistManager *plistManager;
 
 @end
 
@@ -300,10 +300,10 @@
 }
 
 #pragma mark - getters and setters
-- (AIFPListManager *)plistManager
+- (AIFPlistManager *)plistManager
 {
     if (_plistManager == nil) {
-        _plistManager = [[AIFPListManager alloc] init];
+        _plistManager = [[AIFPlistManager alloc] init];
     }
     return _plistManager;
 }

--- a/RTNetworking/Components/Components/LocationComponents/PlistManager/AIFPlistManager.h
+++ b/RTNetworking/Components/Components/LocationComponents/PlistManager/AIFPlistManager.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface AIFPListManager : NSObject
+@interface AIFPlistManager : NSObject
 
 @property (nonatomic, strong, readonly) NSString *fileName;
 @property (nonatomic, copy) id listData; //plist中读出的数据

--- a/RTNetworking/Components/Components/LocationComponents/PlistManager/AIFPlistManager.m
+++ b/RTNetworking/Components/Components/LocationComponents/PlistManager/AIFPlistManager.m
@@ -5,16 +5,16 @@
 //  Copyright 2011 __MyCompanyName__. All rights reserved.
 //
 
-#import "AIFPListManager.h"
+#import "AIFPlistManager.h"
 
-@interface AIFPListManager ()
+@interface AIFPlistManager ()
 
 @property (nonatomic, strong, readwrite) NSString *fileName;
 @property (nonatomic, readwrite) BOOL isBundle;
 
 @end
 
-@implementation AIFPListManager
+@implementation AIFPlistManager
 #pragma mark - life cycle
 - (id)initWithFileName:(NSString *)fileName isBundle:(BOOL)isBundle
 {

--- a/RTNetworking/Components/Components/LogComponents/AIFLogger.m
+++ b/RTNetworking/Components/Components/LogComponents/AIFLogger.m
@@ -10,9 +10,9 @@
 #import "NSObject+AXNetworkingMethods.h"
 #import "NSMutableString+AXNetworkingMethods.h"
 #import "AIFCommonParamsGenerator.h"
-#import "AIFAppContext.h"
+#import "AIFAPPContext.h"
 #import "NSArray+AXNetworkingMethods.h"
-#import "AIFApiProxy.h"
+#import "AIFAPIProxy.h"
 #import "AIFServiceFactory.h"
 
 @interface AIFLogger ()
@@ -37,13 +37,13 @@
     
     NSMutableString *logString = [NSMutableString stringWithString:@"\n\n**************************************************************\n*                       Request Start                        *\n**************************************************************\n\n"];
     
-    [logString appendFormat:@"API Name:\t\t%@\n", [apiName AIF_defaultValue:@"N/A"]];
-    [logString appendFormat:@"Method:\t\t\t%@\n", [httpMethod AIF_defaultValue:@"N/A"]];
-    [logString appendFormat:@"Version:\t\t%@\n", [service.apiVersion AIF_defaultValue:@"N/A"]];
+    [logString appendFormat:@"API Name:\t\t%@\n", [apiName aif_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Method:\t\t\t%@\n", [httpMethod aif_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Version:\t\t%@\n", [service.apiVersion aif_defaultValue:@"N/A"]];
     [logString appendFormat:@"Service:\t\t%@\n", [service class]];
     [logString appendFormat:@"Status:\t\t\t%@\n", isOnline ? @"online" : @"offline"];
-    [logString appendFormat:@"Public Key:\t\t%@\n", [service.publicKey AIF_defaultValue:@"N/A"]];
-    [logString appendFormat:@"Private Key:\t%@\n", [service.privateKey AIF_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Public Key:\t\t%@\n", [service.publicKey aif_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Private Key:\t%@\n", [service.privateKey aif_defaultValue:@"N/A"]];
     [logString appendFormat:@"Params:\n%@", requestParams];
     
     [logString appendURLRequest:request];
@@ -85,11 +85,11 @@
 #ifdef DEBUG
     NSMutableString *logString = [NSMutableString stringWithString:@"\n\n==============================================================\n=                      Cached Response                       =\n==============================================================\n\n"];
     
-    [logString appendFormat:@"API Name:\t\t%@\n", [methodName AIF_defaultValue:@"N/A"]];
-    [logString appendFormat:@"Version:\t\t%@\n", [service.apiVersion AIF_defaultValue:@"N/A"]];
+    [logString appendFormat:@"API Name:\t\t%@\n", [methodName aif_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Version:\t\t%@\n", [service.apiVersion aif_defaultValue:@"N/A"]];
     [logString appendFormat:@"Service:\t\t%@\n", [service class]];
-    [logString appendFormat:@"Public Key:\t\t%@\n", [service.publicKey AIF_defaultValue:@"N/A"]];
-    [logString appendFormat:@"Private Key:\t%@\n", [service.privateKey AIF_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Public Key:\t\t%@\n", [service.publicKey aif_defaultValue:@"N/A"]];
+    [logString appendFormat:@"Private Key:\t%@\n", [service.privateKey aif_defaultValue:@"N/A"]];
     [logString appendFormat:@"Method Name:\t%@\n", methodName];
     [logString appendFormat:@"Params:\n%@\n\n", response.requestParams];
     [logString appendFormat:@"Content:\n\t%@\n\n", response.contentString];
@@ -125,8 +125,8 @@
     actionDict[@"act"] = actionCode;
     [actionDict addEntriesFromDictionary:params];
     [actionDict addEntriesFromDictionary:[AIFCommonParamsGenerator commonParamsDictionaryForLog]];
-    NSDictionary *logJsonDict = @{self.configParams.sendActionKey:[@[actionDict] AX_jsonString]};
-    [[AIFApiProxy sharedInstance] callPOSTWithParams:logJsonDict serviceIdentifier:self.configParams.serviceType methodName:self.configParams.sendActionMethod success:nil fail:nil];
+    NSDictionary *logJsonDict = @{self.configParams.sendActionKey:[@[actionDict] ax_jsonString]};
+    [[AIFAPIProxy sharedInstance] callPOSTWithParams:logJsonDict serviceIdentifier:self.configParams.serviceType methodName:self.configParams.sendActionMethod success:nil fail:nil];
 }
 
 @end

--- a/RTNetworking/Components/Components/LogComponents/AIFLoggerConfiguration.h
+++ b/RTNetworking/Components/Components/LogComponents/AIFLoggerConfiguration.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "AIFAppContext.h"
+#import "AIFAPPContext.h"
 
 @interface AIFLoggerConfiguration : NSObject
 

--- a/RTNetworking/Components/Components/RTAPIBaseManager.m
+++ b/RTNetworking/Components/Components/RTAPIBaseManager.m
@@ -96,14 +96,14 @@
 #pragma mark - public methods
 - (void)cancelAllRequests
 {
-    [[AIFApiProxy sharedInstance] cancelRequestWithRequestIDList:self.requestIdList];
+    [[AIFAPIProxy sharedInstance] cancelRequestWithRequestIDList:self.requestIdList];
     [self.requestIdList removeAllObjects];
 }
 
 - (void)cancelRequestWithRequestId:(NSInteger)requestID
 {
     [self removeRequestIdWithRequestID:requestID];
-    [[AIFApiProxy sharedInstance] cancelRequestWithRequestID:@(requestID)];
+    [[AIFAPIProxy sharedInstance] cancelRequestWithRequestID:@(requestID)];
 }
 
 - (id)fetchDataWithReformer:(id<RTAPIManagerCallbackDataReformer>)reformer

--- a/RTNetworking/Components/Services/AIFService.h
+++ b/RTNetworking/Components/Services/AIFService.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 // 所有AIFService的派生类都要符合这个protocal
-@protocol AIFServiceProtocal <NSObject>
+@protocol AIFServiceProtocol <NSObject>
 
 @property (nonatomic, readonly) BOOL isOnline;
 
@@ -34,6 +34,6 @@
 @property (nonatomic, strong, readonly) NSString *apiBaseUrl;
 @property (nonatomic, strong, readonly) NSString *apiVersion;
 
-@property (nonatomic, weak) id<AIFServiceProtocal> child;
+@property (nonatomic, weak) id<AIFServiceProtocol> child;
 
 @end

--- a/RTNetworking/Components/Services/AIFService.m
+++ b/RTNetworking/Components/Services/AIFService.m
@@ -15,8 +15,8 @@
 {
     self = [super init];
     if (self) {
-        if ([self conformsToProtocol:@protocol(AIFServiceProtocal)]) {
-            self.child = (id<AIFServiceProtocal>)self;
+        if ([self conformsToProtocol:@protocol(AIFServiceProtocol)]) {
+            self.child = (id<AIFServiceProtocol>)self;
         }
     }
     return self;

--- a/RTNetworking/Components/Services/AIFServiceFactory.h
+++ b/RTNetworking/Components/Services/AIFServiceFactory.h
@@ -12,6 +12,6 @@
 @interface AIFServiceFactory : NSObject
 
 + (instancetype)sharedInstance;
-- (AIFService<AIFServiceProtocal> *)serviceWithIdentifier:(NSString *)identifier;
+- (AIFService<AIFServiceProtocol> *)serviceWithIdentifier:(NSString *)identifier;
 
 @end

--- a/RTNetworking/Components/Services/AIFServiceFactory.m
+++ b/RTNetworking/Components/Services/AIFServiceFactory.m
@@ -120,7 +120,7 @@ NSString * const kAIFServiceGoogleMapAPIDirections = @"kAIFServiceGoogleMapAPIDi
 }
 
 #pragma mark - public methods
-- (AIFService<AIFServiceProtocal> *)serviceWithIdentifier:(NSString *)identifier
+- (AIFService<AIFServiceProtocol> *)serviceWithIdentifier:(NSString *)identifier
 {
     if ([self.serviceStorage objectForKey:identifier] == nil) {
         [self.serviceStorage setObject:[self newServiceWithIdentifier:identifier]
@@ -130,7 +130,7 @@ NSString * const kAIFServiceGoogleMapAPIDirections = @"kAIFServiceGoogleMapAPIDi
 }
 
 #pragma mark - private methods
-- (AIFService<AIFServiceProtocal> *)newServiceWithIdentifier:(NSString *)identifier
+- (AIFService<AIFServiceProtocol> *)newServiceWithIdentifier:(NSString *)identifier
 {
     // anjuke
     if ([identifier isEqualToString:kAIFServiceAnjuke]) {

--- a/RTNetworking/Components/Services/GoogleMap/AIFServiceGoogleMapDirections.h
+++ b/RTNetworking/Components/Services/GoogleMap/AIFServiceGoogleMapDirections.h
@@ -8,6 +8,6 @@
 
 #import "AIFService.h"
 
-@interface AIFServiceGoogleMapDirections : AIFService <AIFServiceProtocal>
+@interface AIFServiceGoogleMapDirections : AIFService <AIFServiceProtocol>
 
 @end


### PR DESCRIPTION
1. Delete unnecessary space between return type and method name
2. Add necessary space line between methods
3. Change category method's prefix to lower case
4. Change abbreviate under three letters to upper case
5. Fix typo `protocal` to protocol
